### PR TITLE
Add iconv (required by symfony installer)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ RUN apk --update add \
 	php-ctype \
 	php-json \
 	php-phar \
+	php5-iconv \
 	php-zlib && \
 	rm /var/cache/apk/*
 


### PR DESCRIPTION
Might use php7-iconv when PHP7 gets to stable in alpine
